### PR TITLE
Update SysUserServiceImpl.java

### DIFF
--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysUserServiceImpl.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysUserServiceImpl.java
@@ -162,7 +162,7 @@ public class SysUserServiceImpl implements ISysUserService
     {
         Long userId = StringUtils.isNull(user.getUserId()) ? -1L : user.getUserId();
         SysUser info = userMapper.checkPhoneUnique(user.getPhonenumber());
-        if (StringUtils.isNotNull(info) && info.getUserId().longValue() != userId.longValue())
+        if (StringUtils.isNotEmpty(user.getPhonenumber()) && StringUtils.isNotNull(info) && info.getUserId().longValue() != userId.longValue())
         {
             return UserConstants.NOT_UNIQUE;
         }
@@ -180,7 +180,7 @@ public class SysUserServiceImpl implements ISysUserService
     {
         Long userId = StringUtils.isNull(user.getUserId()) ? -1L : user.getUserId();
         SysUser info = userMapper.checkEmailUnique(user.getEmail());
-        if (StringUtils.isNotNull(info) && info.getUserId().longValue() != userId.longValue())
+        if (StringUtils.isNotEmpty(user.getEmail()) && StringUtils.isNotNull(info) && info.getUserId().longValue() != userId.longValue())
         {
             return UserConstants.NOT_UNIQUE;
         }


### PR DESCRIPTION
漏洞问题：添加无手机号码或者邮箱的用户时还去判断两者的唯一性
造成结果：当数据库已存在无手机号码或者邮箱的用户，此时无法再添加新的无手机号码或者邮箱的用户
解决问题：在判断唯一性时需过滤无填写手机号或邮箱的用户 
`StringUtils.isNotEmpty(user.getPhonenumber())`
`StringUtils.isNotEmpty(user.getEmail())`