### PR TITLE
日期范围自定义参数驼峰转化优化

### DIFF
--- a/ruoyi-ui/src/utils/ruoyi.js
+++ b/ruoyi-ui/src/utils/ruoyi.js
@@ -54,7 +54,7 @@ export function resetForm(refName) {
 }
 
 // 添加日期范围
-export function addDateRange(params, dateRange, propName) {
+export function addDateRange(params, dateRange, propName, camelCase) {
   let search = params;
   search.params = typeof (search.params) === 'object' && search.params !== null && !Array.isArray(search.params) ? search.params : {};
   dateRange = Array.isArray(dateRange) ? dateRange : [];
@@ -62,6 +62,13 @@ export function addDateRange(params, dateRange, propName) {
     search.params['beginTime'] = dateRange[0];
     search.params['endTime'] = dateRange[1];
   } else {
+    // 默认为驼峰形式，可以自行是否需要处理为驼峰
+    if (typeof (camelCase) === 'undefined') {
+      camelCase = true;
+    }
+    if (camelCase) {
+      propName = propName.substring(0, 1).toUpperCase() + propName.substring(1);
+    }
     search.params['begin' + propName] = dateRange[0];
     search.params['end' + propName] = dateRange[1];
   }

--- a/ruoyi-ui/src/utils/ruoyi.js
+++ b/ruoyi-ui/src/utils/ruoyi.js
@@ -62,7 +62,7 @@ export function addDateRange(params, dateRange, propName, camelCase) {
     search.params['beginTime'] = dateRange[0];
     search.params['endTime'] = dateRange[1];
   } else {
-    // 默认为驼峰形式，可以自行是否需要处理为驼峰
+    // 默认为转化为驼峰形式。不转化时请传：false
     if (typeof (camelCase) === 'undefined') {
       camelCase = true;
     }


### PR DESCRIPTION
问题描述：
添加日期范围，一旦key自定义时，没有处理驼峰形式。但是java后端一般都是驼峰形式的命名，导致参数读取不到问题。

举例：
如：自定义参数key为“successTime”，最后传到后端为“beginsuccessTime”，其实转化为“beginSuccessTime”更好。

添加参数：
可能确实有一些不需要驼峰的，addDateRange方法增加了camelCase参数可以传"fasle"来不驼峰