### PR TITLE
fix: 用户初始化进入页面时，若屏幕尺寸太小会出现页签被遮挡的情况。

### DIFF
--- a/ruoyi-ui/src/layout/components/TagsView/ScrollPane.vue
+++ b/ruoyi-ui/src/layout/components/TagsView/ScrollPane.vue
@@ -87,7 +87,7 @@ export default {
       bottom: 0px;
     }
     .el-scrollbar__wrap {
-      height: 49px;
+      // height: 49px;
     }
   }
 }


### PR DESCRIPTION
用户初始化进入页面时，若屏幕尺寸太小会出现页签被遮挡的情况。原有的代码只能解决用户屏幕尺寸太大时页签遮挡的问题，可以使用浏览器的缩放功能验证。原有代码 缩放比例为50%就会遮挡