### PR TITLE
fix(sec): upgrade com.ruoyi:ruoyi-common to 4.7.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>若依管理系统</description>
     
     <properties>
-        <ruoyi.version>3.8.7</ruoyi.version>
+        <ruoyi.version>4.7.8</ruoyi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.ruoyi:ruoyi-common 3.8.7
- [CVE-2022-23868](https://www.oscs1024.com/hd/CVE-2022-23868)


### What did I do？
Upgrade com.ruoyi:ruoyi-common from 3.8.7 to 4.7.8 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS