### PR TITLE
fix: 修复staging环境下babel env不正确导致的打包问题

### DIFF
--- a/ruoyi-ui/.env.staging
+++ b/ruoyi-ui/.env.staging
@@ -3,6 +3,8 @@ VUE_APP_TITLE = 若依管理系统
 
 NODE_ENV = production
 
+BABEL_ENV = production
+
 # 测试环境配置
 ENV = 'staging'
 


### PR DESCRIPTION
vue-cli 在非自带mode下，如"staging"，会出现BABEL_ENV不遵循NODE_ENV的情况，见issue: https://github.com/vuejs/vue-cli/issues/6877,导致出现staging mode下打包会因为dynamic-import-plugin的原因无法完整打包，通过显式指定BABEL_ENV可以解决该问题


