### PR TITLE
fix: 修复代码生成对字段没有进行ognl关键字检查，在特定关键字xor、bor、and、band、eq、shr、shr下导致mybaits报错的BUG

### DIFF
--- a/ruoyi-generator/src/main/java/com/ruoyi/generator/util/GenUtils.java
+++ b/ruoyi-generator/src/main/java/com/ruoyi/generator/util/GenUtils.java
@@ -29,6 +29,20 @@ public class GenUtils
         genTable.setCreateBy(operName);
     }
 
+    public static String processColumnName(String columnName) {
+        String[] ognlField = {"xor","bor","and","band","eq","neq","lt","gt","lte","gte","shl","shr","ushr"};
+        String colName = StringUtils.toCamelCase(columnName);
+
+        for (String field : ognlField) {
+            if (field.equals(colName)) {
+                colName += "Col";
+                break;
+            }
+        }
+
+        return colName;
+    }
+
     /**
      * 初始化列属性字段
      */
@@ -39,7 +53,8 @@ public class GenUtils
         column.setTableId(table.getTableId());
         column.setCreateBy(table.getCreateBy());
         // 设置java字段名
-        column.setJavaField(StringUtils.toCamelCase(columnName));
+        column.setJavaField(processColumnName(columnName));
+
         // 设置默认类型
         column.setJavaType(GenConstants.TYPE_STRING);
         column.setQueryType(GenConstants.QUERY_EQ);


### PR DESCRIPTION
如果数据库中使用了特定的ognl关键词，包含{"xor","bor","and","band","eq","neq","lt","gt","lte","gte","shl","shr","ushr"}，如果没有在代码生成表单页面进行修改Java属性的名称，生成的代码会导致mybaits报错