### PR TITLE
配置Docker化部署支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+target/
+logs/
+*.md
+sql/
+doc/
+bin/
+Dockerfile*
+docker-compose*
+.dockerignore
+.gitignore

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,42 @@
+# 后端 Dockerfile - 多阶段构建
+FROM maven:3.9-eclipse-temurin-17-alpine AS builder
+
+WORKDIR /app
+
+# 复制 pom.xml 和依赖
+COPY pom.xml .
+COPY ruoyi-admin/pom.xml ./ruoyi-admin/pom.xml
+COPY ruoyi-framework/pom.xml ./ruoyi-framework/pom.xml
+COPY ruoyi-system/pom.xml ./ruoyi-system/pom.xml
+COPY ruoyi-quartz/pom.xml ./ruoyi-quartz/pom.xml
+COPY ruoyi-generator/pom.xml ./ruoyi-generator/pom.xml
+COPY ruoyi-common/pom.xml ./ruoyi-common/pom.xml
+RUN mvn dependency:go-offline -B
+
+# 复制源代码并构建
+COPY ruoyi-admin/src ./ruoyi-admin/src
+COPY ruoyi-framework/src ./ruoyi-framework/src
+COPY ruoyi-system/src ./ruoyi-system/src
+COPY ruoyi-quartz/src ./ruoyi-quartz/src
+COPY ruoyi-generator/src ./ruoyi-generator/src
+COPY ruoyi-common/src ./ruoyi-common/src
+RUN mvn clean package -DskipTests -B
+
+# 运行阶段
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+# 创建上传目录
+RUN mkdir -p /app/uploadPath
+
+# 从构建阶段复制 jar 文件
+COPY --from=builder /app/ruoyi-admin/target/ruoyi-admin.jar ./ruoyi-admin.jar
+
+# 复制配置文件
+COPY ruoyi-admin/src/main/resources/application.yml ./config/
+COPY ruoyi-admin/src/main/resources/application-druid.yml ./config/
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "ruoyi-admin.jar", "--spring.config.location=file:./config/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,87 @@
+services:
+  # MySQL 数据库
+  mysql:
+    image: mysql:8.0
+    container_name: ruoyi-mysql
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ruoyi123456
+      MYSQL_DATABASE: ry-vue
+      TZ: Asia/Shanghai
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./sql:/docker-entrypoint-initdb.d
+    command:
+      --default-authentication-plugin=mysql_native_password
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --skip-character-set-client-handshake
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - ruoyi-network
+
+  # Redis 缓存
+  redis:
+    image: redis:7-alpine
+    container_name: ruoyi-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - ruoyi-network
+
+  # 后端 Spring Boot
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    container_name: ruoyi-backend
+    restart: always
+    ports:
+      - "8091:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: druid
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/ruoyi?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Shanghai&useSSL=false&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: ruoyi123456
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - ruoyi-network
+
+  # 前端 Nginx
+  frontend:
+    build:
+      context: ./ruoyi-ui
+      dockerfile: Dockerfile.nginx
+    container_name: ruoyi-frontend
+    restart: always
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    networks:
+      - ruoyi-network
+
+volumes:
+  mysql_data:
+  redis_data:
+
+networks:
+  ruoyi-network:
+    driver: bridge

--- a/ruoyi-admin/src/main/resources/application-druid.yml
+++ b/ruoyi-admin/src/main/resources/application-druid.yml
@@ -6,9 +6,9 @@ spring:
         druid:
             # 主库数据源
             master:
-                url: jdbc:mysql://localhost:3306/ry-vue?useUnicode=true&characterEncoding=utf8&zeroDateTimeBehavior=convertToNull&useSSL=true&serverTimezone=GMT%2B8
+                url: jdbc:mysql://mysql:3306/ry-vue?useUnicode=true&characterEncoding=UTF-8&connectionCollation=utf8mb4_unicode_ci&zeroDateTimeBehavior=convertToNull&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true
                 username: root
-                password: password
+                password: ruoyi123456
             # 从库数据源
             slave:
                 # 从数据源开关/默认关闭

--- a/ruoyi-admin/src/main/resources/application.yml
+++ b/ruoyi-admin/src/main/resources/application.yml
@@ -20,6 +20,12 @@ server:
   servlet:
     # 应用的访问路径
     context-path: /
+    encoding:
+      enabled: true
+      charset: UTF-8
+      force: true
+      forceRequest: true
+      forceResponse: true
   tomcat:
     # tomcat的URI编码
     uri-encoding: UTF-8
@@ -63,6 +69,8 @@ spring:
   jackson:
     time-zone: GMT+8
     date-format: yyyy-MM-dd HH:mm:ss
+    generator: { write_dates_as_timestamps: false }
+    charset: UTF-8
   # 服务模块
   devtools:
     restart:

--- a/ruoyi-ui/Dockerfile.nginx
+++ b/ruoyi-ui/Dockerfile.nginx
@@ -1,0 +1,27 @@
+# 前端 Nginx Dockerfile
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# 安装依赖
+COPY package*.json ./
+RUN npm install
+
+# 复制源代码
+COPY . .
+
+# 构建生产版本
+RUN npm run build:prod
+
+# Nginx 运行阶段
+FROM nginx:alpine
+
+# 复制构建产物
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# 复制 Nginx 配置
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/ruoyi-ui/nginx.conf
+++ b/ruoyi-ui/nginx.conf
@@ -1,0 +1,70 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    # 设置默认字符集
+    charset utf-8;
+
+    # 强制 UTF-8 响应头
+    add_header Content-Type "text/html; charset=utf-8";
+
+    # 前端静态文件
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA 支持
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # 静态资源
+    location ~* \.(js|css|html|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        charset utf-8;
+    }
+
+    # API 代理到后端
+    location /prod-api/ {
+        proxy_pass http://backend:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 超时设置
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # 代理其他 API 路径（如 /api/, /swagger-ui/ 等）
+    location /api/ {
+        proxy_pass http://backend:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /swagger-ui/ {
+        proxy_pass http://backend:8080/;
+        proxy_set_header Host $host;
+    }
+
+    # 静态资源缓存
+    location /static/ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # 上传文件路径
+    location /profile/ {
+        proxy_pass http://backend:8080/;
+        proxy_set_header Host $host;
+    }
+
+    # Gzip 压缩
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
+}


### PR DESCRIPTION
## Summary
- 添加 Dockerfile.backend 和 docker-compose.yml 支持容器编排
- 添加前端 nginx Dockerfile 和 nginx.conf 配置
- 更新 application-druid.yml 数据源配置适配容器网络 (mysql:3306)
- 更新 application.yml 添加字符编码和 Jackson UTF-8 配置
- 添加 .dockerignore 排除不必要的构建文件

## Test plan
- [ ] 验证 Docker Compose 可以正常启动所有服务
- [ ] 验证前端通过 Nginx 代理可以正常访问后端 API
- [ ] 验证数据库字符编码正确（中文显示正常）