### PR TITLE
feat(menu): 实现菜单父级变更时自动同步角色权限功能

### DIFF
--- a/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysRoleMenuMapper.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysRoleMenuMapper.java
@@ -41,4 +41,21 @@ public interface SysRoleMenuMapper
      * @return 结果
      */
     public int batchRoleMenu(List<SysRoleMenu> roleMenuList);
+
+    /**
+     * 查询拥有指定菜单权限的所有角色ID
+     *
+     * @param menuId 菜单ID
+     * @return 角色ID列表
+     */
+    public List<Long> selectRoleIdsByMenuId(Long menuId);
+
+    /**
+     * 批量为多个角色添加菜单权限（忽略重复）
+     *
+     * @param roleMenuList 角色菜单列表
+     * @return 结果
+     */
+    public int batchInsertRoleMenuIgnore(List<SysRoleMenu> roleMenuList);
+
 }

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysMenuServiceImpl.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysMenuServiceImpl.java
@@ -8,6 +8,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.ruoyi.system.domain.SysRoleMenu;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -319,8 +321,18 @@ public class SysMenuServiceImpl implements ISysMenuService
      * @return 结果
      */
     @Override
+    @Transactional
     public int updateMenu(SysMenu menu)
     {
+        // 获取修改前的菜单信息
+        SysMenu oldMenu = menuMapper.selectMenuById(menu.getMenuId());
+
+        // 如果父菜单发生了变化，需要自动同步角色权限
+        if (oldMenu != null && !oldMenu.getParentId().equals(menu.getParentId()))
+        {
+            syncRoleMenuForParentChange(menu.getMenuId(), menu.getParentId());
+        }
+
         return menuMapper.updateMenu(menu);
     }
 
@@ -614,5 +626,45 @@ public class SysMenuServiceImpl implements ISysMenuService
     {
         return StringUtils.replaceEach(path, new String[] { Constants.HTTP, Constants.HTTPS, Constants.WWW, ".", ":" },
                 new String[] { "", "", "", "/", "/" });
+    }
+
+
+    /**
+     * 当菜单的父级发生变化时，自动同步角色权限
+     * 为所有拥有该菜单的角色添加新父菜单的权限
+     *
+     * @param menuId 菜单ID
+     * @param newParentId 新的父菜单ID
+     */
+    private void syncRoleMenuForParentChange(Long menuId, Long newParentId)
+    {
+        // 如果新父菜单是根目录（0），则不需要同步
+        if (MENU_ROOT_ID.equals(newParentId))
+        {
+            log.info("菜单 [{}] 移动到根目录，无需同步父菜单权限", menuId);
+            return;
+        }
+
+        // 查询所有拥有该菜单权限的角色ID
+        List<Long> roleIds = roleMenuMapper.selectRoleIdsByMenuId(menuId);
+
+        if (roleIds == null || roleIds.isEmpty())
+        {
+            log.info("菜单 [{}] 未被任何角色关联，无需同步", menuId);
+            return;
+        }
+
+        // 为这些角色批量添加新父菜单的权限（使用 ignore 避免重复）
+        List<SysRoleMenu> roleMenuList = new ArrayList<>();
+        for (Long roleId : roleIds)
+        {
+            SysRoleMenu roleMenu = new SysRoleMenu();
+            roleMenu.setRoleId(roleId);
+            roleMenu.setMenuId(newParentId);
+            roleMenuList.add(roleMenu);
+        }
+
+        int result = roleMenuMapper.batchInsertRoleMenuIgnore(roleMenuList);
+        log.info("菜单 [{}] 移动成功，成功同步 [{}] 个角色权限", menuId, result);
     }
 }

--- a/ruoyi-system/src/main/resources/mapper/system/SysRoleMenuMapper.xml
+++ b/ruoyi-system/src/main/resources/mapper/system/SysRoleMenuMapper.xml
@@ -30,5 +30,17 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			(#{item.roleId},#{item.menuId})
 		</foreach>
 	</insert>
+
+    <select id="selectRoleIdsByMenuId" resultType="Long">
+        select distinct role_id from sys_role_menu where menu_id = #{menuId}
+    </select>
+
+
+    <insert id="batchInsertRoleMenuIgnore">
+        insert ignore into sys_role_menu(role_id, menu_id) values
+        <foreach item="item" index="index" collection="list" separator=",">
+            (#{item.roleId},#{item.menuId})
+        </foreach>
+    </insert>
 	
 </mapper> 


### PR DESCRIPTION
在移动菜单从主目录到其它目录时角色不会自动关联修改后的目录，用户可能会忘记去修改角色权限导致查看不到菜单，新增菜单父级变更时自动同步角色权限功能