### PR TITLE
fix: import useDict in Vue3 generator template

### DIFF
--- a/ruoyi-generator/src/main/resources/vm/vue/v3/index.vue.vm
+++ b/ruoyi-generator/src/main/resources/vm/vue/v3/index.vue.vm
@@ -388,6 +388,9 @@
 
 <script setup name="${BusinessName}">
 import { list${BusinessName}, get${BusinessName}, del${BusinessName}, add${BusinessName}, update${BusinessName} } from "@/api/${moduleName}/${businessName}"
+#if(${dicts} != '')
+import { useDict } from '@/utils/dict'
+#end
 #if($genView)
 import ${BusinessName}ViewDrawer from "./view"
 #end


### PR DESCRIPTION
## What

Import `useDict` in generated Vue3 pages when dictionary fields are present.

## Why

The template invokes `useDict` for dictionary-enabled modules but does not import it, causing generated pages to fail compilation.

## Validation

- `git diff --check`
- Generate a Vue3 page with dictionary fields and verify that the generated script contains the import.

Fixes #152